### PR TITLE
Fix caption lookups, highlighting

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -485,7 +485,7 @@ var FilteredList = function(array, filterText) {
         var upper = needle.toUpperCase();
         var lower = needle.toLowerCase();
         loop: for (var i = 0, item; item = items[i]; i++) {
-            var caption = item.value || item.caption || item.snippet;
+            var caption = item.caption || item.value || item.snippet;
             if (!caption) continue;
             var lastIndex = -1;
             var matchMask = 0;


### PR DESCRIPTION
If completions have a `caption` which does not match the `value`, it will either not be found or be highlighted wrong in the completions dropdown.

This is because, the display prefers `caption` over `value` if it exists (see [here](https://github.com/looker/ace/blob/0a3b002e285a41a4884ce42f94d2f68673e43b30/lib/ace/autocomplete/popup.js#L181-L181)), but the search and highlight code was preferring `value` over `caption`.
