### PR TITLE
Append tooltip to body to ensure good positioning

### DIFF
--- a/lib/ace/mouse/default_gutter_handler.js
+++ b/lib/ace/mouse/default_gutter_handler.js
@@ -38,7 +38,7 @@ var Tooltip = require("../tooltip").Tooltip;
 function GutterHandler(mouseHandler) {
     var editor = mouseHandler.editor;
     var gutter = editor.renderer.$gutterLayer;
-    var tooltip = new GutterTooltip(editor.container);
+    var tooltip = new GutterTooltip(window.document.body);
 
     mouseHandler.editor.setDefaultHandler("guttermousedown", function(e) {
         if (!editor.isFocused() || e.getButton() != 0)


### PR DESCRIPTION
Tooltip positioning was being messed up in our modal because of the position on the modal's container.  Skip the issue by appending the tooltip to the body instead of the editor container so that the mouse coords it uses to compute position are always correct.
