### PR TITLE
[EX-887] feat(autocomplete): adds CSS to support the in use field use case

### DIFF
--- a/lib/ace/autocomplete/popup.js
+++ b/lib/ace/autocomplete/popup.js
@@ -369,6 +369,18 @@ dom.importCssString("\
     color: #c1c1c1;\
 }", "autocompletion.css");
 
+/**
+ * We create a separated CSS file that only has the necessary CSS
+ * to style fields used by the query
+ */
+dom.importCssString("\
+.ace_editor.ace_autocomplete .ace_line .ace_in-use-field-completion:before {\
+    content: '•';\
+    padding-right: 5px;\
+    color: #1A73E8;\
+}\
+", "inuse-autocomplete.css")
+
 exports.AcePopup = AcePopup;
 exports.$singleLineEditor = $singleLineEditor;
 });


### PR DESCRIPTION
*Issue #: * JIRA ticket [#887](https://looker.atlassian.net/browse/EX-887)

*Description of changes:*
We add some special CSS to the autocomplete popup to support the case for `In Use` fields inside the explore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

@looker/explore 