### PR TITLE
feat(popup): we removed the previous added CSS for in-use fields

### DIFF
--- a/lib/ace/autocomplete/popup.js
+++ b/lib/ace/autocomplete/popup.js
@@ -369,18 +369,6 @@ dom.importCssString("\
     color: #c1c1c1;\
 }", "autocompletion.css");
 
-/**
- * We create a separated CSS file that only has the necessary CSS
- * to style fields used by the query
- */
-dom.importCssString("\
-.ace_editor.ace_autocomplete .ace_line .ace_in-use-field-completion:before {\
-    content: '•';\
-    padding-right: 5px;\
-    color: #1A73E8;\
-}\
-", "inuse-autocomplete.css")
-
 exports.AcePopup = AcePopup;
 exports.$singleLineEditor = $singleLineEditor;
 });


### PR DESCRIPTION
*Description of changes:*
The blue dot CSS solution didn't work out as expected because it is using the token as a source of true. But multiple tokens are generated at the same row when someone start typing on the editor, making this solution less than ideal.
We decided to use another solution with a simple unicode prefix at the completion caption that doesn't require CSS intervention. That makes this CSS unnecessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
